### PR TITLE
The less empty() the better the code!

### DIFF
--- a/classes/BlueChip/Security/Helpers/FormHelper.php
+++ b/classes/BlueChip/Security/Helpers/FormHelper.php
@@ -174,7 +174,7 @@ abstract class FormHelper
             function ($value) {
                 return is_int($value)
                     || is_float($value)
-                    || (is_string($value) && !empty($value))
+                    || (is_string($value) && $value !== '')
                     || (is_bool($value) && $value)
                 ;
             }


### PR DESCRIPTION
@chesio There are standards like https://github.com/slevomat/coding-standard#slevomatcodingstandardcontrolstructuresdisallowempty