### PR TITLE
Clean up global instance variable

### DIFF
--- a/bc-security.php
+++ b/bc-security.php
@@ -63,3 +63,6 @@ register_deactivation_hook(__FILE__, [$bc_security, 'deactivate']);
 
 // Boot up the plugin immediately after all plugins are loaded.
 add_action('plugins_loaded', [$bc_security, 'load'], 0, 0);
+
+// Clean up global instance variable.
+unset($bc_security);


### PR DESCRIPTION
Breaks this line https://github.com/chesio/bc-security/blob/37483924ff2b9ae4221d1b6ee236c552e396172c/tests/integration/src/Bootstrap.php#L69-L70

@chesio What do you think?