### PR TITLE
Remove core function from bootstrap.php

### DIFF
--- a/tests/static-analysis/bootstrap.php
+++ b/tests/static-analysis/bootstrap.php
@@ -7,6 +7,3 @@ define('WP_PLUGIN_URL', '');
 define('AUTH_COOKIE', '');
 define('SECURE_AUTH_COOKIE', '');
 define('LOGGED_IN_COOKIE', '');
-
-// Upcoming in WordPress 6.4:
-function wp_admin_notice (string $message, array $args): void {}


### PR DESCRIPTION
Already included in latest WP core stubs.

From https://github.com/chesio/bc-security/actions/runs/7745557030/job/21121844739